### PR TITLE
Potential fix for code scanning alert no. 2: Clear-text logging of sensitive information

### DIFF
--- a/internal/database/connect.go
+++ b/internal/database/connect.go
@@ -49,7 +49,13 @@ func Connect() {
 		},
 	)
 
-	log.Println(dsn)
+	sanitizedDsn := fmt.Sprintf("%s:****@tcp(%s:%d)/%s?charset=utf8mb4&parseTime=True&loc=Local",
+		c.User,
+		c.Host,
+		c.Port,
+		c.Name,
+	)
+	log.Println(sanitizedDsn)
 	DB, err = gorm.Open(mysql.Open(dsn), &gorm.Config{
 		Logger: newLogger,
 	})


### PR DESCRIPTION
Potential fix for [https://github.com/scharph-io/orda/security/code-scanning/2](https://github.com/scharph-io/orda/security/code-scanning/2)

To fix the problem, we need to ensure that sensitive information such as the database password is not logged in clear text. The best way to fix this issue without changing existing functionality is to remove the password from the `dsn` string before logging it. We can achieve this by creating a sanitized version of the `dsn` string that omits the password and then logging this sanitized version instead.

We will make the following changes to the file `internal/database/connect.go`:
1. Create a sanitized version of the `dsn` string that omits the password.
2. Log the sanitized `dsn` string instead of the original `dsn` string.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
