### PR TITLE
Potential fix for code scanning alert no. 6: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/makefile.yml
+++ b/.github/workflows/makefile.yml
@@ -8,6 +8,9 @@ on:
     branches:
       - master
 
+permissions:
+  contents: read
+
 env:
   IMAGE: orda
 


### PR DESCRIPTION
Potential fix for [https://github.com/scharph-io/orda/security/code-scanning/6](https://github.com/scharph-io/orda/security/code-scanning/6)

To fix the issue, we will add a `permissions` block at the root level of the workflow to define the minimal permissions required. Based on the workflow's operations, it primarily interacts with repository contents (e.g., checking out the repository) and does not need write access. Therefore, we will set `contents: read` as the minimal permission. If additional permissions are required in the future, they can be added explicitly.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
